### PR TITLE
Fix initial-cash help text

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -134,7 +134,12 @@ def create_workflow(selected_analysts=None):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Run the hedge fund trading system")
-    parser.add_argument("--initial-cash", type=float, default=100000.0, help="Initial cash position. Defaults to 100000.0)")
+    parser.add_argument(
+        "--initial-cash",
+        type=float,
+        default=100000.0,
+        help="Initial cash position. Defaults to 100000.0",
+    )
     parser.add_argument("--margin-requirement", type=float, default=0.0, help="Initial margin requirement. Defaults to 0.0")
     parser.add_argument("--tickers", type=str, required=True, help="Comma-separated list of stock ticker symbols")
     parser.add_argument(


### PR DESCRIPTION
## Summary
- fix typo in `--initial-cash` help string

## Testing
- `python -m py_compile src/main.py`
- `pytest -q`
